### PR TITLE
more Android work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ hs_err_pid*
 build/
 
 /.idea/*
+*.iml
 out/
 
 !/.idea/copyright/

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiContextImpl.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiContextImpl.kt
@@ -86,7 +86,6 @@ internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : Zi
     init {
         controller = Controller(URI.create(id.controller()).toURL(), sslContext(), trustManager(), sessionToken)
         this.enabled = enabled
-        //initialize()
     }
 
     override fun dial(serviceName: String): ZitiConnection {

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiImpl.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiImpl.kt
@@ -32,6 +32,15 @@ import java.security.PKCS12Attribute
 
 internal object ZitiImpl : Logged by JULogged() {
 
+    internal val onAndroid: Boolean by lazy {
+        try {
+            Class.forName("android.util.Log")
+            true
+        } catch (cnf: ClassNotFoundException) {
+            false
+        }
+    }
+
     init {
         i("ZitiSDK version ${Version.version} @${Version.revision}(${Version.branch})")
     }

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/HTTP.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/HTTP.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019 NetFoundry, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netfoundry.ziti.net.internal
+
+import io.netfoundry.ziti.ZitiException
+import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.Logged
+import java.lang.reflect.Field
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.net.URLStreamHandlerFactory
+
+internal object HTTP: Logged by JULogged() {
+
+    const val HTTP_PORT = 80
+    const val HTTPS_PORT = 443
+
+    lateinit var defaultHTTPSHandler: URLStreamHandler
+    lateinit var defaultHTTPHandler: URLStreamHandler
+    lateinit var facField: Field
+
+    fun init() {
+        try {
+            val handlerField =
+                URL::class.java.getDeclaredField("handler").apply { isAccessible = true }
+            defaultHTTPSHandler = URL("https://google.com").let {
+                handlerField.get(it) as URLStreamHandler
+            }
+            defaultHTTPHandler = URL("http://google.com").let {
+                handlerField.get(it) as URLStreamHandler
+            }
+
+            facField = URL::class.java.getDeclaredField("factory").apply { isAccessible = true }
+        } catch (ex: Exception) {
+            e("$ex")
+        }
+
+        try {
+            i("setting Ziti URLStreamFactory")
+            URL.setURLStreamHandlerFactory(Factory())
+        } catch (ex: Error) {
+            w("$ex")
+        }
+    }
+
+    class Factory : URLStreamHandlerFactory {
+        override fun createURLStreamHandler(protocol: String?): URLStreamHandler? {
+            return when (protocol) {
+                "https" -> Handler(HTTPS_PORT, defaultHTTPSHandler)
+                "http" -> Handler(HTTP_PORT, defaultHTTPHandler)
+                else -> null
+            }
+        }
+    }
+
+    class Handler(val defPort: Int, val defHandler: URLStreamHandler) : URLStreamHandler() {
+
+        override fun getDefaultPort() = defPort
+
+        override fun openConnection(u: URL): URLConnection {
+            try {
+                when(u.protocol) {
+                    "https" -> return ZitiHTTPSConnection(u)
+                    "http" -> return ZitiHTTPConnection(u)
+                    else -> throw IllegalArgumentException("Unsupported URL protocol")
+                }
+            } catch (ex: ZitiException) {
+                return URL(u, "", defHandler).openConnection()
+            }
+        }
+
+    }
+}

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/Sockets.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/Sockets.kt
@@ -16,6 +16,7 @@
 
 package io.netfoundry.ziti.net.internal
 
+import io.netfoundry.ziti.impl.ZitiImpl
 import io.netfoundry.ziti.net.ZitiSocketImpl
 import io.netfoundry.ziti.util.JULogged
 import io.netfoundry.ziti.util.Logged
@@ -40,6 +41,10 @@ internal object Sockets : Logged by JULogged() {
     fun init() {
         d { "internals initialized" }
         Socket.setSocketImplFactory { ZitiSocketImpl() }
+
+        if (ZitiImpl.onAndroid) {
+            HTTP.init()
+        }
     }
 
     class BypassSocket : Socket(defaultImplCons.newInstance())

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPConnection.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPConnection.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2019 NetFoundry, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netfoundry.ziti.net.internal
+
+import io.netfoundry.ziti.net.ZitiSocketImpl
+import io.netfoundry.ziti.net.dns.ZitiDNSManager
+import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.Logged
+import okhttp3.*
+import okhttp3.internal.http.HttpMethod
+import okio.BufferedSink
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.Socket
+import java.net.URL
+import java.security.KeyStore
+import java.security.cert.Certificate
+import javax.net.SocketFactory
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+class ZitiHTTPConnection(url: URL) :
+    HttpURLConnection(url),
+    Logged by JULogged("ziti-http")
+{
+    override fun usingProxy(): Boolean = false
+
+    val body = ByteArrayOutputStream(1024)
+    val req = Request.Builder().apply {
+        url(this@ZitiHTTPConnection.url)
+    }
+
+    lateinit var call: Call
+
+    override fun setRequestMethod(method: String) {
+        super.setRequestMethod(method)
+        if (HttpMethod.permitsRequestBody(method)) {
+            req.method(method, object : RequestBody(){
+                override fun contentType(): MediaType? {
+                    return req.build().header("Content-Type")?.let { MediaType.parse(it) }
+                }
+
+                override fun contentLength(): Long {
+                    return body.size().toLong()
+                }
+
+                override fun writeTo(sink: BufferedSink) {
+                    sink.write(body.toByteArray())
+                }
+            })
+        } else {
+            req.method(method, null)
+        }
+    }
+
+    override fun setRequestProperty(key: String?, value: String?) {
+        super.setRequestProperty(key, value)
+        req.header(key, value)
+    }
+
+    override fun addRequestProperty(key: String?, value: String?) {
+        super.addRequestProperty(key, value)
+        req.addHeader(key, value)
+    }
+
+    override fun connect() {
+        execute()
+    }
+
+    override fun disconnect() {
+        d("disconnect()")
+    }
+
+    override fun getResponseCode(): Int {
+        return execute().code()
+    }
+
+    override fun getResponseMessage(): String {
+        return execute().message()
+    }
+
+    override fun getHeaderField(name: String?): String? {
+        return execute().header(name)
+    }
+
+    override fun getContentLengthLong(): Long {
+        return execute().body()?.contentLength() ?: 0
+    }
+
+    override fun getHeaderFields(): MutableMap<String, MutableList<String>> {
+        return execute().headers().toMultimap()
+    }
+
+    override fun getContentLength(): Int {
+        return execute().body()?.contentLength()?.toInt() ?: 0
+    }
+
+    override fun getOutputStream(): OutputStream {
+        return body
+    }
+
+    override fun getInputStream(): InputStream {
+        execute()
+        return response?.body()?.byteStream()!!
+    }
+
+    inner class Output : OutputStream() {
+        override fun write(b: Int) = error("not implemented")
+    }
+
+    fun execute(): Response {
+        if (response == null) {
+            val request = req.build()
+            d("executing $request")
+            val newCall = clt.newCall(request)
+            response = newCall.execute()
+            d("finished executing ${response}")
+        }
+
+        return response!!
+    }
+
+    var response: Response? = null
+
+    companion object {
+
+        val factory = object : SocketFactory(){
+            override fun createSocket(): Socket = ZitiSocket(ZitiSocketImpl())
+
+            override fun createSocket(p0: String?, p1: Int): Socket {
+                error("not implemented")
+            }
+
+            override fun createSocket(p0: String?, p1: Int, p2: InetAddress?, p3: Int): Socket {
+                error("not implemented")
+            }
+
+            override fun createSocket(p0: InetAddress?, p1: Int): Socket {
+                error("not implemented")
+            }
+
+            override fun createSocket(p0: InetAddress?, p1: Int, p2: InetAddress?, p3: Int): Socket {
+                error("not implemented")
+            }
+        }
+
+        val clt = OkHttpClient.Builder()
+            .retryOnConnectionFailure(false)
+            .socketFactory(factory)
+            .dns{ hostname ->
+                mutableListOf(ZitiDNSManager.resolve(hostname))
+            }
+            .build()
+
+    }
+}

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPSConnection.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPSConnection.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2019 NetFoundry, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netfoundry.ziti.net.internal
+
+import io.netfoundry.ziti.net.dns.ZitiDNSManager
+import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.Logged
+import okhttp3.*
+import okhttp3.internal.http.HttpMethod
+import okio.BufferedSink
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.Socket
+import java.net.URL
+import java.security.KeyStore
+import java.security.cert.Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+class ZitiHTTPSConnection(url: URL) :
+    HttpsURLConnection(url),
+    Logged by JULogged("ziti-https")
+{
+    override fun usingProxy(): Boolean = false
+
+    val body = ByteArrayOutputStream(1024)
+    val req = Request.Builder().apply {
+        url(this@ZitiHTTPSConnection.url)
+    }
+
+    lateinit var call: Call
+
+    override fun setRequestMethod(method: String) {
+        super.setRequestMethod(method)
+        if (HttpMethod.permitsRequestBody(method)) {
+            req.method(method, object : RequestBody(){
+                override fun contentType(): MediaType? {
+                    return req.build().header("Content-Type")?.let { MediaType.parse(it) }
+                }
+
+                override fun contentLength(): Long {
+                    return body.size().toLong()
+                }
+
+                override fun writeTo(sink: BufferedSink) {
+                    sink.write(body.toByteArray())
+                }
+            })
+        } else {
+            req.method(method, null)
+        }
+    }
+
+    override fun setRequestProperty(key: String?, value: String?) {
+        super.setRequestProperty(key, value)
+        req.header(key, value)
+    }
+
+    override fun addRequestProperty(key: String?, value: String?) {
+        super.addRequestProperty(key, value)
+        req.addHeader(key, value)
+    }
+
+    override fun connect() {
+        execute()
+    }
+
+    override fun disconnect() {
+        d("disconnect()")
+    }
+
+    override fun getResponseCode(): Int {
+        return execute().code()
+    }
+
+    override fun getResponseMessage(): String {
+        return execute().message()
+    }
+
+    override fun getHeaderField(name: String?): String? {
+        return execute().header(name)
+    }
+
+    override fun getContentLengthLong(): Long {
+        return execute().body()?.contentLength() ?: 0
+    }
+
+    override fun getHeaderFields(): MutableMap<String, MutableList<String>> {
+        return execute().headers().toMultimap()
+    }
+
+    override fun getContentLength(): Int {
+        return execute().body()?.contentLength()?.toInt() ?: 0
+    }
+
+    override fun getServerCertificates(): Array<Certificate> {
+        error("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getCipherSuite(): String {
+        error("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getLocalCertificates(): Array<Certificate> {
+        error("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getOutputStream(): OutputStream {
+        return body
+    }
+
+    override fun getInputStream(): InputStream {
+        execute()
+        return response?.body()?.byteStream()!!
+    }
+
+    fun execute(): Response {
+        if (response == null) {
+            val request = req.build()
+            d("executing $request")
+            val newCall = clt.newCall(request)
+            response = newCall.execute()
+            d("finished executing ${response}")
+        }
+
+        return response!!
+    }
+
+    var response: Response? = null
+
+    companion object {
+        val sslFactory = object : SSLSocketFactory() {
+            override fun createSocket(s: Socket?, host: String?, port: Int, autoClose: Boolean): Socket {
+                s ?: throw IllegalArgumentException("transport socket == null")
+                val addr = ZitiDNSManager.resolve(host!!)
+                return ZitiSSLSocket(s, addr!!, port)
+            }
+
+            override fun createSocket(host: String?, port: Int): Socket {
+                error("not implemented")
+            }
+
+            override fun createSocket(host: String?, port: Int, localHost: InetAddress?, localPort: Int): Socket {
+                error("not implemented")
+            }
+
+            override fun createSocket(host: InetAddress?, port: Int): Socket {
+                error("not implemented")
+            }
+
+            override fun createSocket(address: InetAddress?, port: Int, localAddress: InetAddress?, localPort: Int): Socket {
+                error("not implemented")
+            }
+
+            override fun getSupportedCipherSuites(): Array<String> {
+                return (SSLSocketFactory.getDefault() as SSLSocketFactory).supportedCipherSuites
+            }
+
+            override fun getDefaultCipherSuites(): Array<String> {
+                return (SSLSocketFactory.getDefault() as SSLSocketFactory).defaultCipherSuites
+            }
+        }
+
+        val tm = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).apply {
+            val ks = KeyStore.getInstance(KeyStore.getDefaultType())
+            init(ks)
+        }
+
+        val clt = OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .sslSocketFactory(sslFactory, tm.trustManagers[0] as X509TrustManager)
+                .dns{ hostname ->
+                    mutableListOf(ZitiDNSManager.resolve(hostname))
+                }
+                .build()
+
+    }
+}

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSSLSocket.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSSLSocket.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2019 NetFoundry, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netfoundry.ziti.net.internal
+
+import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.Logged
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.security.KeyStore
+import java.security.SecureRandom
+import javax.net.ssl.*
+
+class ZitiSSLSocket(val transport: Socket, val host: InetAddress, val pport: Int) :
+    SSLSocket(host, pport),
+    Logged by JULogged("ziti-ssl-socket")
+{
+
+    inner class Output : OutputStream() {
+        val buffer = ByteBuffer.allocate(32 * 1024)
+        override fun write(b: Int) {
+            buffer.put(b.toByte())
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            d{"writing $len bytes (${String(b, off, len)})"}
+            if (len + buffer.position() > buffer.capacity()) {
+                flush()
+            }
+            buffer.put(b, off, len)
+        }
+
+        override fun flush() {
+            val wrapped = ByteBuffer.allocate(32 * 1024)
+            buffer.flip()
+            if (buffer.hasRemaining()) {
+                val res = engine.wrap(buffer, wrapped)
+                d{"flushing ${res.bytesProduced()} bytes"}
+                transport.getOutputStream()?.apply {
+                    write(wrapped.array(), 0, wrapped.position())
+                    flush()
+                }
+            }
+            buffer.clear()
+        }
+    }
+
+    val output = Output()
+    override fun getOutputStream(): OutputStream = output
+
+    inner class Input : InputStream() {
+        override fun read(): Int {
+            return transport.getInputStream().read()
+        }
+
+        override fun read(out: ByteArray?, off: Int, len: Int): Int {
+            transport.getInputStream()?.let {
+                val buffer = ByteBuffer.allocate(32 * 1024)
+                val b = ByteArray(32 * 1024)
+                val read = it.read(b)
+                if (read > 0) {
+                    buffer.put(b, 0, read)
+                    buffer.flip()
+
+                    val res = engine.unwrap(buffer, ByteBuffer.wrap(out, off, len))
+                    d{"read read=$read consumed=${res.bytesConsumed()} produced=${res.bytesProduced()} (${String(out!!, off, res.bytesProduced())})"}
+                    return res.bytesProduced()
+                }
+                else {
+                    return read
+                }
+            }
+
+            return -1
+        }
+    }
+
+    val input = Input()
+    override fun getInputStream(): InputStream = input
+
+    override fun startHandshake() {
+        engine.beginHandshake()
+    }
+
+
+    override fun getSession(): SSLSession {
+
+        val empty = ByteBuffer.wrap(ByteArray(0))
+
+        while (engine.handshakeStatus != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+            d("continuing handshake status=${engine.handshakeStatus}")
+
+            when (engine.handshakeStatus) {
+                SSLEngineResult.HandshakeStatus.NEED_WRAP -> {
+                    val wrapped = ByteBuffer.allocate(32 * 1024)
+                    val res = engine.wrap(empty, wrapped)
+                    d("res = $res")
+                    transport.getOutputStream().apply {
+                        write(wrapped.array(), 0, res.bytesProduced())
+                        flush()
+                    }
+                }
+                SSLEngineResult.HandshakeStatus.NEED_TASK -> {
+                    engine.delegatedTask?.run()
+                }
+                SSLEngineResult.HandshakeStatus.NEED_UNWRAP -> {
+                    val unwrapped = ByteBuffer.allocate(32 * 1024)
+                    val ssl_in = ByteArray(32 * 1024)
+                    var read = 0
+                    var processed = 0
+                    var res: SSLEngineResult
+
+                    while (engine.handshakeStatus == SSLEngineResult.HandshakeStatus.NEED_UNWRAP) {
+
+                        val r = transport.getInputStream().read(ssl_in, read, ssl_in.size - read)
+                        if (r == -1) {
+                            break
+                        }
+                        read += r
+
+                        v("read $r/$read")
+
+                        while (read > processed) {
+                            v("unwrapping bytes $processed..$read")
+                            res = engine.unwrap(ByteBuffer.wrap(ssl_in, processed, read - processed), unwrapped)
+                            v("res = $res")
+                            processed += res.bytesConsumed()
+
+                            if (res.status == SSLEngineResult.Status.BUFFER_UNDERFLOW) {
+                                break
+                            }
+                        }
+                    }
+
+
+                    if (read > processed) {
+                        e("unprocessed SSL bytes")
+                    }
+                }
+
+                SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING -> return engine.session
+
+                else -> { }
+            }
+        }
+        return engine.session
+    }
+
+    override fun setUseClientMode(mode: Boolean) {
+        engine.useClientMode = mode
+    }
+
+    override fun setEnabledProtocols(protocols: Array<out String>?) {
+        engine.enabledProtocols = protocols
+    }
+
+    override fun setEnabledCipherSuites(suites: Array<out String>?) {
+        engine.enabledCipherSuites = suites
+    }
+
+    override fun getUseClientMode(): Boolean = engine.useClientMode
+
+    override fun getEnableSessionCreation(): Boolean = engine.enableSessionCreation
+
+    override fun getEnabledProtocols(): Array<String> = engine.enabledProtocols
+
+    override fun getWantClientAuth(): Boolean = engine.wantClientAuth
+
+    override fun getNeedClientAuth(): Boolean = engine.needClientAuth
+
+    override fun getEnabledCipherSuites(): Array<String> = engine.enabledCipherSuites
+
+    override fun setNeedClientAuth(need: Boolean) {
+        engine.needClientAuth = need
+    }
+
+    override fun getSupportedCipherSuites(): Array<String> = engine.supportedCipherSuites
+
+    override fun setWantClientAuth(want: Boolean) {
+        engine.wantClientAuth = want
+    }
+
+    override fun getSupportedProtocols(): Array<String> = engine.supportedProtocols
+
+    override fun addHandshakeCompletedListener(listener: HandshakeCompletedListener?) {
+        error("not implemented")
+    }
+
+    override fun removeHandshakeCompletedListener(listener: HandshakeCompletedListener?) {
+        error("not implemented")
+    }
+
+    override fun setEnableSessionCreation(flag: Boolean) {
+        engine.enableSessionCreation = flag
+    }
+
+    val engine: SSLEngine
+
+    init {
+        val ssl = SSLContext.getInstance("TLSv1.2")
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(null as KeyStore?)
+        ssl.init(null, tmf.trustManagers, SecureRandom())
+
+        engine = ssl.createSSLEngine(host.hostName, pport)
+        engine.useClientMode = true
+    }
+}

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSocket.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSocket.kt
@@ -20,7 +20,7 @@ import io.netfoundry.ziti.ZitiConnection
 import io.netfoundry.ziti.net.ZitiSocketImpl
 import java.net.Socket
 
-internal class ZitiSocket private constructor(internal val zitiImpl: ZitiSocketImpl) : Socket(zitiImpl) {
+internal class ZitiSocket internal constructor(internal val zitiImpl: ZitiSocketImpl) : Socket(zitiImpl) {
 
     constructor(zc: ZitiConnection) : this(ZitiSocketImpl(zc))
 

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSocketImpl.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSocketImpl.kt
@@ -75,7 +75,7 @@ internal class ZitiSocketImpl(zc: ZitiConnection? = null): SocketImpl(), Logged 
             } catch (zex: ZitiException) {
                 when (zex.code) {
                     Errors.NotEnrolled, Errors.ServiceNotAvailable -> {
-                        w("failed to connect to $address: ${zex.message}. Trying fallback")
+                        w("failed to connect to $address using ctx[${ctx.name()}]: ${zex.message}. Trying fallback")
                     }
                     else -> throw zex
                 }
@@ -94,7 +94,7 @@ internal class ZitiSocketImpl(zc: ZitiConnection? = null): SocketImpl(), Logged 
         connected = true;
     }
 
-    internal fun fallbackConnect(address: SocketAddress?, timeout: Int) {
+    private fun fallbackConnect(address: SocketAddress?, timeout: Int) {
         fallback!!.connect(address, timeout)
         connected = true
     }


### PR DESCRIPTION
On Android we need special handling  in order in _intercept_ HTTP(S) traffic. This has to do with the way Android delegates TLS handling into native libraries.