### PR TITLE
Android logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,36 @@
+Ziti SDK for JVM
+=================
+The **Ziti SDK for JVM** enables Java and other developers to easily and securely connect their applications
+to backend services over NetFoundry Ziti networks.
+
+.. contents::
+
+
+Release Notes
+-------------
+
+
+Obtaining SDK
+------------
+
+
+
+Building from Source
+--------------------
+
+Features
+--------
+
+
+Getting Help
+------------
+Please use these community resources for getting help. We use GitHub [issues][sdk-issues] for tracking bugs and feature requests and have limited bandwidth
+to address them.
+* Read the [docs][ziti-docs]
+* Participate in discussion on [Discourse][nf-discourse]
+
+
+
+[ziti-docs]: https://netfoundry.github.io/ziti-doc/ziti/overview.html
+[nf-discourse]: https://netfoundry.discourse.group/
+[sdk-issues]: https://github.com/NetFoundry/ziti-sdk-jvm/issues

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/api/Controller.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/api/Controller.kt
@@ -21,7 +21,7 @@ import io.netfoundry.ziti.Errors
 import io.netfoundry.ziti.ZitiException
 import io.netfoundry.ziti.getZitiError
 import io.netfoundry.ziti.net.internal.Sockets
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import io.netfoundry.ziti.util.Version
 import kotlinx.coroutines.Deferred
@@ -44,7 +44,7 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
 
 class Controller(endpoint: URL, sslContext: SSLContext?, trustManager: X509TrustManager, sessToken: String? = null) :
-    Logged by JULogged() {
+    Logged by ZitiLog() {
     val SdkInfo = mapOf("type" to "ziti-sdk-java") + Version.VersionInfo
 
     internal interface API {

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiContextImpl.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiContextImpl.kt
@@ -29,7 +29,7 @@ import io.netfoundry.ziti.net.Channel
 import io.netfoundry.ziti.net.ZitiConn
 import io.netfoundry.ziti.net.dns.ZitiDNSManager
 import io.netfoundry.ziti.net.internal.ZitiSocket
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import kotlinx.coroutines.*
 import java.net.InetSocketAddress
@@ -44,7 +44,7 @@ import kotlin.properties.Delegates
  *
  */
 internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : ZitiContext, Identity by id,
-    CoroutineScope, Logged by JULogged() {
+    CoroutineScope, Logged by ZitiLog() {
 
     enum class Status {
         Active,

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiImpl.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/impl/ZitiImpl.kt
@@ -26,7 +26,7 @@ import java.io.File
 import java.net.URI
 import java.security.KeyStore
 
-internal object ZitiImpl : Logged by JULogged() {
+internal object ZitiImpl : Logged by ZitiLog() {
 
     internal val onAndroid: Boolean by lazy {
         try {

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/Channel.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/Channel.kt
@@ -19,7 +19,7 @@ package io.netfoundry.ziti.net
 import io.netfoundry.ziti.Errors
 import io.netfoundry.ziti.ZitiException
 import io.netfoundry.ziti.identity.Identity
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.channels.Channel as Chan
 
-internal class Channel(val peer: Transport) : Closeable, CoroutineScope, Logged by JULogged() {
+internal class Channel(val peer: Transport) : Closeable, CoroutineScope, Logged by ZitiLog() {
 
     private val supervisor = SupervisorJob()
     override val coroutineContext: CoroutineContext

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/Transport.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/Transport.kt
@@ -17,7 +17,7 @@
 package io.netfoundry.ziti.net
 
 import io.netfoundry.ziti.net.internal.Sockets
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import java.io.Closeable
 import java.io.InputStream
@@ -64,7 +64,7 @@ internal interface Transport : Closeable {
         return count
     }
 
-    class TLS(host: String, port: Int, sslContext: SSLContext) : Transport, Logged by JULogged("ziti-tls") {
+    class TLS(host: String, port: Int, sslContext: SSLContext) : Transport, Logged by ZitiLog("ziti-tls") {
         val socket: SSLSocket
 
         init {

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/ZitiConn.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/ZitiConn.kt
@@ -18,7 +18,7 @@ package io.netfoundry.ziti.net
 
 import io.netfoundry.ziti.ZitiConnection
 import io.netfoundry.ziti.api.NetworkSession
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
@@ -38,7 +38,7 @@ import kotlinx.coroutines.channels.Channel as Chan
  *
  */
 internal class ZitiConn(networkSession: NetworkSession, val channel: Channel) : ZitiConnection,
-    Closeable, Logged by JULogged("ziti-conn") {
+    Closeable, Logged by ZitiLog("ziti-conn") {
     enum class State {
         New,
         Connected,

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/HTTP.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/HTTP.kt
@@ -17,12 +17,12 @@
 package io.netfoundry.ziti.net.internal
 
 import io.netfoundry.ziti.net.dns.ZitiDNSManager
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import java.lang.reflect.Field
 import java.net.*
 
-internal object HTTP: Logged by JULogged() {
+internal object HTTP: Logged by ZitiLog() {
 
     const val HTTP_PORT = 80
     const val HTTPS_PORT = 443

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/Sockets.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/Sockets.kt
@@ -18,14 +18,14 @@ package io.netfoundry.ziti.net.internal
 
 import io.netfoundry.ziti.impl.ZitiImpl
 import io.netfoundry.ziti.net.ZitiSocketImpl
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import java.lang.reflect.Constructor
 import java.net.Socket
 import java.net.SocketImpl
 import java.util.concurrent.atomic.AtomicBoolean
 
-internal object Sockets : Logged by JULogged() {
+internal object Sockets : Logged by ZitiLog() {
 
     private val initialized = AtomicBoolean(false)
 

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPConnection.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPConnection.kt
@@ -18,7 +18,7 @@ package io.netfoundry.ziti.net.internal
 
 import io.netfoundry.ziti.net.ZitiSocketImpl
 import io.netfoundry.ziti.net.dns.ZitiDNSManager
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import okhttp3.*
 import okhttp3.internal.http.HttpMethod
@@ -34,7 +34,7 @@ import javax.net.SocketFactory
 
 class ZitiHTTPConnection(url: URL) :
     HttpURLConnection(url),
-    Logged by JULogged("ziti-http")
+    Logged by ZitiLog("ziti-http")
 {
     override fun usingProxy(): Boolean = false
 

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPSConnection.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiHTTPSConnection.kt
@@ -17,7 +17,7 @@
 package io.netfoundry.ziti.net.internal
 
 import io.netfoundry.ziti.net.dns.ZitiDNSManager
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import okhttp3.*
 import okhttp3.internal.http.HttpMethod
@@ -37,7 +37,7 @@ import javax.net.ssl.X509TrustManager
 
 class ZitiHTTPSConnection(url: URL) :
     HttpsURLConnection(url),
-    Logged by JULogged("ziti-https")
+    Logged by ZitiLog("ziti-https")
 {
     override fun usingProxy(): Boolean = false
 

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSSLSocket.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSSLSocket.kt
@@ -16,7 +16,7 @@
 
 package io.netfoundry.ziti.net.internal
 
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import java.io.InputStream
 import java.io.OutputStream
@@ -29,7 +29,7 @@ import javax.net.ssl.*
 
 class ZitiSSLSocket(val transport: Socket, val host: InetAddress, val pport: Int) :
     SSLSocket(host, pport),
-    Logged by JULogged("ziti-ssl-socket")
+    Logged by ZitiLog("ziti-ssl-socket")
 {
 
     inner class Output : OutputStream() {

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSocketImpl.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/net/internal/ZitiSocketImpl.kt
@@ -21,12 +21,12 @@ import io.netfoundry.ziti.ZitiConnection
 import io.netfoundry.ziti.ZitiException
 import io.netfoundry.ziti.impl.ZitiImpl
 import io.netfoundry.ziti.net.internal.Sockets
-import io.netfoundry.ziti.util.JULogged
+import io.netfoundry.ziti.util.ZitiLog
 import io.netfoundry.ziti.util.Logged
 import java.io.FileDescriptor
 import java.net.*
 
-internal class ZitiSocketImpl(zc: ZitiConnection? = null): SocketImpl(), Logged by JULogged("ziti.socket.impl") {
+internal class ZitiSocketImpl(zc: ZitiConnection? = null): SocketImpl(), Logged by ZitiLog("ziti.socket.impl") {
 
     var connected: Boolean = false
     var closed: Boolean = false

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/util/Log.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/util/Log.kt
@@ -55,7 +55,7 @@ internal fun getDelegate(name: String): Logged {
     }
 }
 
-internal class JULogged(name: String, private val delegate: Logged = getDelegate(name)) : Logged by delegate {
+internal class ZitiLog(name: String, private val delegate: Logged = getDelegate(name)) : Logged by delegate {
     constructor() :
             this(getCaller().split(".").last())
 

--- a/ziti/src/main/kotlin/io/netfoundry/ziti/util/Log.kt
+++ b/ziti/src/main/kotlin/io/netfoundry/ziti/util/Log.kt
@@ -16,6 +16,7 @@
 
 package io.netfoundry.ziti.util
 
+import java.lang.reflect.Method
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -43,11 +44,31 @@ internal interface Logged {
     fun t(msg: String) = t { msg }
 }
 
-internal class JULogged(val name: String) : Logged {
-    val logger: Logger = Logger.getLogger(name)
+internal fun getDelegate(name: String): Logged {
 
+    try {
+        Class.forName("android.util.Log")
+        return AndroidLogged(name)
+    }
+    catch (ex: Throwable) {
+        return JULoggedImpl(name)
+    }
+}
+
+internal class JULogged(name: String, private val delegate: Logged = getDelegate(name)) : Logged by delegate {
     constructor() :
             this(getCaller().split(".").last())
+
+    companion object {
+        fun getCaller(): String {
+            val ex = Exception().stackTrace
+            return ex[2].className
+        }
+    }
+}
+
+internal class JULoggedImpl(val name: String) : Logged {
+    private val logger: Logger = Logger.getLogger(name)
 
     override fun e(msg: LogMsg) = e(null, msg)
 
@@ -62,11 +83,60 @@ internal class JULogged(val name: String) : Logged {
     override fun v(msg: LogMsg) = logger.logp(Level.FINER, name, "", msg)
 
     override fun t(msg: LogMsg) = logger.logp(Level.FINEST, name, "", msg)
+}
+
+internal class AndroidLogged(val tag: String): Logged {
+
+    override fun e(msg: LogMsg) {
+        err(null, tag, msg(), null)
+    }
+
+    override fun e(ex: Throwable?, msg: LogMsg) {
+        err(null, tag, msg(), ex)
+    }
+
+    override fun w(msg: LogMsg) {
+        warn(null, tag, msg(), null)
+
+    }
+
+    override fun i(msg: LogMsg) {
+        info(null, tag, msg(), null)
+    }
+
+    override fun d(msg: LogMsg) {
+        dbg(null, tag, msg(), null)
+    }
+
+    override fun v(msg: LogMsg) {
+        verb(null, tag, msg(), null)
+    }
+
+    override fun t(msg: LogMsg) {
+        trace(null, tag, msg(), null)
+    }
 
     companion object {
-        fun getCaller(): String {
-            val ex = Exception().stackTrace
-            return ex[2].className
+        lateinit var err: Method
+        lateinit var warn: Method
+        lateinit var info: Method
+        lateinit var dbg: Method
+        lateinit var verb: Method
+        lateinit var trace: Method
+
+        init {
+            try {
+                val logCls = Class.forName("android.util.Log")
+
+                err = logCls.getDeclaredMethod("e", String::class.java, String::class.java, Throwable::class.java)
+                warn = logCls.getDeclaredMethod("w", String::class.java, String::class.java, Throwable::class.java)
+                info = logCls.getDeclaredMethod("w", String::class.java, String::class.java, Throwable::class.java)
+                dbg = logCls.getDeclaredMethod("d", String::class.java, String::class.java, Throwable::class.java)
+                verb = logCls.getDeclaredMethod("v", String::class.java, String::class.java, Throwable::class.java)
+                trace = verb
+            } catch (ex: ClassNotFoundException) {
+                // ignore as we should not be here
+            }
         }
     }
 }


### PR DESCRIPTION
java.util.logging messages with level DEBUG or below do not show up in logcat. 
Use ZitiLog to redirect messages to android logging (android.util.Log methods).
